### PR TITLE
Removes contamination with var from tests and adds support for Terraform 0.13 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ Check out some use cases in the [examples][3].
 
 ### Credentials
 
-The module starts from the assumption that the `aws_login_profile` allows the
-user to assume the necessary IAM roles, as required, to make the necessary
-changes (and in the case of the `satellite` module, cross-account).
-
 See [this example][4] to first make sure that the credentials you want to use
 allow for cross-account actions.
 
@@ -38,7 +34,6 @@ Obviously, all the [supported authentication][6] methods can also be used.
 |------|-------------|------|---------|:-----:|
 | aws\_account\_id\_hub | AWS account number containing the TGW hub | `string` | n/a | yes |
 | aws\_account\_id\_satellite | List of AWS account numbers representing the satellites of the TGW | `list` | n/a | yes |
-| aws\_login\_profile | Name of the AWS login profile as seen under ~/.aws/config used for assuming cross-account roles | `any` | n/a | yes |
 | description | Description of the Transit Gateway | `string` | n/a | yes |
 | name | Name to be used on all the resources as identifier | `string` | n/a | yes |
 | role\_to\_assume\_hub | IAM role name to assume in the AWS account containing the TGW hub (eg. ASSUME-ROLE-HUB) | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "aws_ec2_transit_gateway" "this" {
   default_route_table_propagation = var.default_route_table_propagation
   auto_accept_shared_attachments  = "enable"
 
-  tags = merge(var.tags, map("Name", var.name))
+  tags = merge(var.tags, tomap({ "Name" = var.name }))
 }
 
 resource "aws_ec2_transit_gateway_route_table" "this" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,34 +1,34 @@
 output "transit_gateway_arn" {
   description = "ARN of the Transit Gateway"
-  value       = element(concat(aws_ec2_transit_gateway.this.*.arn, list("")), 0)
+  value       = element(concat(aws_ec2_transit_gateway.this.*.arn, tolist([])), 0)
 }
 
 output "transit_gateway_id" {
   description = "Identifier of the Transit Gateway"
-  value       = element(concat(aws_ec2_transit_gateway.this.*.id, list("")), 0)
+  value       = element(concat(aws_ec2_transit_gateway.this.*.id, tolist([])), 0)
 }
 
 output "transit_gateway_route_table_id" {
   description = "Identifier of the Transit Gateway Route Table"
-  value       = element(concat(aws_ec2_transit_gateway_route_table.this.*.id, list("")), 0)
+  value       = element(concat(aws_ec2_transit_gateway_route_table.this.*.id, tolist([])), 0)
 }
 
 output "ram_resource_share_arn" {
   description = "ARN of the Resource Access Manager Resource Share"
-  value       = element(concat(aws_ram_resource_share.this.*.arn, list("")), 0)
+  value       = element(concat(aws_ram_resource_share.this.*.arn, tolist([])), 0)
 }
 
 output "ram_resource_share_id" {
   description = "Identifier of the Resource Access Manager Resource Share"
-  value       = element(concat(aws_ram_resource_share.this.*.id, list("")), 0)
+  value       = element(concat(aws_ram_resource_share.this.*.id, tolist([])), 0)
 }
 
 output "ram_principal_association_id" {
   description = "Identifier of the Resource Access Manager Principal Association"
-  value       = element(concat(aws_ram_principal_association.this.*.id, list("")), 0)
+  value       = element(concat(aws_ram_principal_association.this.*.id, tolist([])), 0)
 }
 
 output "ram_resource_association_id" {
   description = "Identifier of the Resource Access Manager Resource Association"
-  value       = element(concat(aws_ram_resource_association.this.*.id, list("")), 0)
+  value       = element(concat(aws_ram_resource_association.this.*.id, tolist([])), 0)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "default_route_table_propagation" {
 
 variable "aws_account_id_satellite" {
   description = "List of AWS account numbers representing the satellites of the TGW"
-  type        = list
+  type        = list(any)
 }
 
 variable "aws_account_id_hub" {

--- a/variables.tf
+++ b/variables.tf
@@ -35,10 +35,6 @@ variable "aws_account_id_hub" {
   type        = string
 }
 
-variable "aws_login_profile" {
-  description = "Name of the AWS login profile as seen under ~/.aws/config used for assuming cross-account roles"
-}
-
 variable "role_to_assume_hub" {
   description = "IAM role name to assume in the AWS account containing the TGW hub (eg. ASSUME-ROLE-HUB)"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
# Removes contamination with var from tests and adds support for Terraform 0.13 and above

## Description
Self-explanatory.

## Testing Instructions
N/A


## How to roll out
N/A


## Notes
N/A


## Demo
N/A